### PR TITLE
perf: prepare pagination without converting resource collection data into array

### DIFF
--- a/src/Resources/JsonApiResourceCollection.php
+++ b/src/Resources/JsonApiResourceCollection.php
@@ -74,23 +74,21 @@ class JsonApiResourceCollection extends ResourceCollection
         $resource->setPageName('page[number]')
             ->withQueryString();
 
-        $paginated = $resource->toArray();
-
         $this->with = [
             'links' => [
-                'first' => $paginated['first_page_url'],
-                'last' => $paginated['last_page_url'],
-                'prev' => $paginated['prev_page_url'],
-                'next' => $paginated['next_page_url'],
+                'first' => $resource->url(1),
+                'last' => $resource->url($resource->lastPage()),
+                'prev' => $resource->previousPageUrl(),
+                'next' => $resource->nextPageUrl(),
             ],
             'meta' => [
                 'currentPage' => $resource->currentPage(),
                 'lastPage' => $resource->lastPage(),
-                'from' => $paginated['from'],
-                'to' => $paginated['to'],
+                'from' => $resource->firstItem(),
+                'to' => $resource->lastItem(),
                 'total' => $resource->total(),
                 'pageSize' => $resource->perPage(),
-                'path' => $paginated['path'],
+                'path' => $resource->path(),
             ],
         ];
 


### PR DESCRIPTION
I just noticed while profiling that the controller needs 20ms to return the JsonResouceCollection. 
The `preparePaginationFieldsDepth` methods takes some time because $paginator->toArray() executes this method:
```
class LengthAwarePaginator {
    public function toArray()
    {
        return [
            'data' => $this->items->toArray(),
            // and a lot of usefullpagination fields
        ];
    }
}
```